### PR TITLE
feat: deploy automatically to maven central (wip)

### DIFF
--- a/.flattened-pom.xml
+++ b/.flattened-pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.openresourcediscovery</groupId>
     <artifactId>annotations</artifactId> <!-- aggregator/parent -->
-    <version>${revision}</version>
+    <version>0.0.1</version>
     <packaging>pom</packaging>
     <name>ORD Java Parent</name>
     <description>Parent/aggregator for ORD annotations and models</description>

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,27 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Set version
+        run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }}
+      - name: Publish package
+        run: mvn -P release --batch-mode deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}


### PR DESCRIPTION
**Introduce Maven Central deployment for `ord-maven`**  

This PR adds configuration to publish the `ord-maven` package to Maven Central using GitHub Actions.  

- Configured GitHub action to maven central via workflow  
- Introduced a `release` profile with the ```flatten-maven-plugin``` to resolve ```${revision}```, ```central-publishing-maven-plugin```, ```maven-source-plugin``` and  ```maven-gpg-plugin``` 

This enables automated releases directly to Maven Central.  

**TODO before merge:**  
- [ ] Register and confirm Maven Central account, namespace, and retrieve username/token  
- [ ] Generate and configure GPG keypair for artifact signing  