### PR TITLE
CI: Enforce annotated schema for annotation generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
             - models/src/main/java
 
             Changes are automatically pushed to 'generated-sources' by the CI workflow on main.
-          base: ci/fix-schema-verification
+          base: main
           add-paths: |
             annotations/**
             models/**


### PR DESCRIPTION
This PR updates the CI workflow to only accept Document.annotated.schema.json for annotation generation.